### PR TITLE
esp-http-client: set username and password in esp_http_client_init()

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -535,6 +535,14 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
     client->parser->data = client;
     client->event.client = client;
 
+    if (config->username) {
+        client->connection_info.username = config->username;
+    }
+
+    if (config->password) {
+        client->connection_info.password = config->password;
+    }
+
     client->state = HTTP_STATE_INIT;
     return client;
 }


### PR DESCRIPTION
Username and password in the configuration parameter used for HTTP client initialization are not forwarded to the HTTP client handle, thus, no authentication is sent into the HTTP header.